### PR TITLE
Fix path issues when using installed gem

### DIFF
--- a/lib/mli.rb
+++ b/lib/mli.rb
@@ -2,7 +2,7 @@ require "faraday"
 require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem
-loader.ignore("lib/mli/cli*")
+loader.ignore("#{__dir__}/mli/cli*")
 loader.setup
 
 module Mli

--- a/lib/mli/cli.rb
+++ b/lib/mli/cli.rb
@@ -6,5 +6,5 @@ module Mli
 end
 
 loader = Zeitwerk::Loader.new
-loader.push_dir("lib/mli/cli", namespace: Mli::Cli)
+loader.push_dir("#{__dir__}/cli", namespace: Mli::Cli)
 loader.setup

--- a/lib/mli/cli/base_command.rb
+++ b/lib/mli/cli/base_command.rb
@@ -13,7 +13,7 @@ module Mli
       end
 
       def self.docs_for(topic, section)
-        topic_data = File.read("docs/#{topic}.txt")
+        topic_data = File.read("#{__dir__}/../../../docs/#{topic}.txt")
         sections_data = {}
         topic_data.split("// ").each do |section_part|
           name, *rest = section_part.split("\n")

--- a/spec/lib/mli/cli/base_command_spec.rb
+++ b/spec/lib/mli/cli/base_command_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Mli::Cli::BaseCommand do
 
       before do
         found_doc_data = File.read("spec/fixtures/cli/doc.txt")
-        allow(File).to receive(:read).with("docs/found.txt").and_return(found_doc_data)
+        expect(File).to receive(:read).with(match("docs/found.txt")).and_return(found_doc_data)
       end
 
       context "with a missing section" do


### PR DESCRIPTION
When actually installing and using the gem on my system I hit some path issues. This stuff didn't come up previously because I was always running the code from the project rather than actually running `rake install` and then trying it like that. My approach was to just more closely follow the Zeitwerk docs and use that fancy `__dir__` variable so that paths are absolute.