### PR TITLE
Setup release process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "bump"
 gem "irb"
 gem "rake"
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    bump (0.10.0)
     date (3.4.1)
     diff-lcs (1.6.2)
     erb (5.0.2)
@@ -107,6 +108,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bump
   irb
   mli!
   rake

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ And that's it! Upgrading is the same.
 > This will install to the current Ruby so keep in mind that other Rubies could
 > have an older version or no version at all.
 
+## Releasing
+
+This gem is not published to RubyGems.org but I'm still tagging releases so to
+cut a new version do this:
+
+```bash
+./bin/release
+```
+
+This will:
+
+* bump the patch level version
+* make a commit
+* tag that commit
+* push the new commit
+* push the tag
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License][MIT].

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,6 @@
+#! /bin/sh
+set -ex
+
+bump patch --tag
+git push origin main
+git push origin --tags

--- a/lib/mli/cli/root_command.rb
+++ b/lib/mli/cli/root_command.rb
@@ -1,13 +1,13 @@
 module Mli
   module Cli
     class RootCommand < Thor
-      desc "ping", "Work with the /api/v1/ping family of endpoints."
+      desc "ping", "Use /api/v1/ping endpoint family"
       subcommand "ping", PingCommand
 
-      desc "vanishing_messages", "Work with the /api/v1/vanishing_messages family of endpoints."
+      desc "vanishing_messages", "Use /api/v1/vanishing_messages endpoint family"
       subcommand "vanishing_messages", VanishingMessagesCommand
 
-      desc "version", "Print the version number."
+      desc "version", "Print the version number"
       def version
         say Mli::VERSION
       end

--- a/spec/fixtures/cli/help.txt
+++ b/spec/fixtures/cli/help.txt
@@ -1,6 +1,6 @@
 Commands:
   mli help [COMMAND]      # Describe available commands or one specific command
-  mli ping                # Work with the /api/v1/ping family of endpoints.
-  mli vanishing_messages  # Work with the /api/v1/vanishing_messages family o...
-  mli version             # Print the version number.
+  mli ping                # Use /api/v1/ping endpoint family
+  mli vanishing_messages  # Use /api/v1/vanishing_messages endpoint family
+  mli version             # Print the version number
 


### PR DESCRIPTION
This PR adds the bump gem to the project for dealing with the version number and sets up a release process. I'm going to manually tag v0.0.1 and then I can use this process for the next bump. Hopefully it works!! 😝 