### PR TITLE
Update executable setup

### DIFF
--- a/exe/mli
+++ b/exe/mli
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
+lib = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
 require "mli"
 require "mli/cli"
 


### PR DESCRIPTION
I'm not 100% sure why I added that `bundler/setup` require but it def broke things! What I discovered:

* when I would run `$ exe/mli foo` from this project folder then everything was fine
* when I would run from a new shell (defaulted to my home dir) everything was fine
* but when I was in a folder that included Bundler it would not work

The error I would get would look something like this:

```
jon@mister-sinister:~/code/jonallured.com(ruby-3.4.8*)% jay version
/Users/jon/.asdf/installs/ruby/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- jay (LoadError)
	from /Users/jon/.asdf/installs/ruby/3.4.8/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from /Users/jon/.asdf/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/jay-0.0.1/exe/jay:4:in '<top (required)>'
	from /Users/jon/.asdf/installs/ruby/3.4.8/bin/jay:25:in 'Kernel#load'
	from /Users/jon/.asdf/installs/ruby/3.4.8/bin/jay:25:in '<main>'
```

Of course that was for `jay` but same idea. After some back-and-forth with Claude we figured it out and this was the simple fix.