### PR TITLE
Configure spec task without verbose output

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,6 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "standard/rake"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) { |t| t.verbose = false }
 
 task default: %i[standard spec]


### PR DESCRIPTION
Turns out this is the magic incantation to turn off the bonus output when running RSpec with Rake.

## Before

```
jon@mister-sinister:~/code/mli(main)% be rake
Inspecting 30 files
..............................

30 files inspected, no offenses detected
/Users/jon/.asdf/installs/ruby/3.4.8/bin/ruby -I/Users/jon/.asdf/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.6/lib:/Users/jon/.asdf/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rspec-support-3.13.6/lib /Users/jon/.asdf/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rspec-core-3.13.6/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Randomized with seed 55186
...............................................

Finished in 0.02797 seconds (files took 0.10737 seconds to load)
47 examples, 0 failures

Randomized with seed 55186
```

## After

```
jon@mister-sinister:~/code/mli(configure-spec-without-verbose-output)% be rake
Inspecting 30 files
..............................

30 files inspected, no offenses detected

Randomized with seed 61341
...............................................

Finished in 0.02503 seconds (files took 0.10776 seconds to load)
47 examples, 0 failures

Randomized with seed 61341
```

Eliminating noise is my favorite thing to do!