### PR TITLE
Use options instead of method args

### DIFF
--- a/docs/books.txt
+++ b/docs/books.txt
@@ -1,15 +1,8 @@
 // create
   POST /api/v1/books
 
-  Attributes:
-    * finished_on: date, required
-    * format: string, required, one of: audio, kindle, print
-    * isbn: string, required
-    * pages: number, optional
-    * title: string, optional
-
   Example:
-    $ mli books create finished_on:2025-01-01 format:print isbn:123-456-789
+    $ mli books create --finished-on today --format print --isbn 123-456-789
 
 // delete
   DELETE /api/v1/books/:id
@@ -20,28 +13,14 @@
 // list
   GET /api/v1/books
 
-  Params:
-    * page: number, optional - defaults to 1
-
-  Examples:
-    Get the first page of books:
-    $ mli books list
-
-    Get the third page of books:
-    $ mli books list 3
+  Example:
+    $ mli books list --page 3
 
 // update
   PUT /api/v1/books/:id
 
-  Attributes:
-    * finished_on: date, required
-    * format: string, required, one of: audio, kindle, print
-    * isbn: string, required
-    * pages: number, optional
-    * title: string, optional
-
   Example:
-    $ mli books update 1 pages:100
+    $ mli books update 1 --pages 100
 
 // view
   GET /api/v1/books/:id

--- a/docs/vanishing_messages.txt
+++ b/docs/vanishing_messages.txt
@@ -1,8 +1,5 @@
 // create
   POST /api/v1/vanishing_messages
 
-  Attributes:
-    * body: text, required
-
   Example:
-    $ mli vanishing_messages create body:shhh
+    $ mli vanishing_messages create --body shhh

--- a/lib/mli/cli/base_command.rb
+++ b/lib/mli/cli/base_command.rb
@@ -3,15 +3,6 @@ module Mli
     class BaseCommand < Thor
       class_option :pretty, type: :boolean, default: false, desc: "Format JSON response"
 
-      def self.attrs_for(args)
-        Array(args).each_with_object({}) do |pair, memo|
-          key, value = pair.split(":")
-          next unless key && value
-
-          memo[key] = value
-        end
-      end
-
       def self.docs_for(topic, section)
         topic_data = File.read("#{__dir__}/../../../docs/#{topic}.txt")
         sections_data = {}
@@ -22,14 +13,10 @@ module Mli
         sections_data[section.to_s]
       end
 
-      private
-
-      def attrs_for(args)
-        self.class.attrs_for(args)
-      end
-
-      def formatted(data)
-        options["pretty"] ? JSON.pretty_generate(data) : JSON.generate(data)
+      no_commands do
+        def formatted(data)
+          options[:pretty] ? JSON.pretty_generate(data) : JSON.generate(data)
+        end
       end
     end
   end

--- a/lib/mli/cli/books_command.rb
+++ b/lib/mli/cli/books_command.rb
@@ -1,37 +1,67 @@
 module Mli
   module Cli
     class BooksCommand < BaseCommand
-      desc "create ATTRS", "Create Book record with ATTRS"
+      desc "create", "Create Book resource"
       long_desc docs_for(:books, :create), wrap: false
-      def create(*args)
-        book_attrs = attrs_for(args)
+      option :finished_on, type: :string, required: true, desc: "YYYY-MM-DD or today"
+      option :format, type: :string, required: true, enum: %w[audio kindle print]
+      option :isbn, type: :string, required: true, desc: "Used to populate pages/title"
+      option :pages, type: :numeric, required: false
+      option :title, type: :string, required: false
+      def create
+        finished_on = (options[:finished_on] == "today") ? Date.today.to_s : options[:finished_on]
+
+        book_attrs = {
+          finished_on: finished_on,
+          format: options[:format],
+          isbn: options[:isbn],
+          pages: options[:pages],
+          title: options[:title]
+        }.compact
+
         book_data = Books.create(book_attrs)
         say formatted(book_data)
       end
 
-      desc "delete ID", "Delete Book record for ID"
+      desc "delete ID", "Delete Book resource with ID"
       long_desc docs_for(:books, :delete), wrap: false
       def delete(book_id)
         book_data = Books.delete(book_id)
         say formatted(book_data)
       end
 
-      desc "list [PAGE]", "List Book records by PAGE"
+      desc "list", "List Book resources"
       long_desc docs_for(:books, :list), wrap: false
-      def list(page = 1)
+      option :page, type: :numeric, default: 1, required: false
+      def list
+        page = options[:page]
         books_data = Books.list(page)
         say formatted(books_data)
       end
 
-      desc "update ID ATTRS", "Update Book record for ID with ATTRS"
+      desc "update ID", "Update Book resource with ID"
       long_desc docs_for(:books, :update), wrap: false
-      def update(book_id, *args)
-        book_attrs = attrs_for(args)
+      option :finished_on, type: :string, required: false, desc: "YYYY-MM-DD or today"
+      option :format, type: :string, required: false, enum: %w[audio kindle print]
+      option :isbn, type: :string, required: false, desc: "Used to populate pages/title"
+      option :pages, type: :numeric, required: false
+      option :title, type: :string, required: false
+      def update(book_id)
+        finished_on = (options[:finished_on] == "today") ? Date.today.to_s : options[:finished_on]
+
+        book_attrs = {
+          finished_on: finished_on,
+          format: options[:format],
+          isbn: options[:isbn],
+          pages: options[:pages],
+          title: options[:title]
+        }.compact
+
         book_data = Books.update(book_id, book_attrs)
         say formatted(book_data)
       end
 
-      desc "view ID", "View Book record for ID"
+      desc "view ID", "View Book resource with ID"
       long_desc docs_for(:books, :view), wrap: false
       def view(book_id)
         book_data = Books.view(book_id)

--- a/lib/mli/cli/ping_command.rb
+++ b/lib/mli/cli/ping_command.rb
@@ -4,16 +4,8 @@ module Mli
       desc "get", "Get server time"
       long_desc docs_for(:ping, :get), wrap: false
       def get
-        server_time = Ping.get
-        say formatted(server_time)
-      end
-
-      private
-
-      def formatted(data)
-        return data unless options["pretty"]
-
-        JSON.pretty_generate({server_time: data})
+        ping_data = Ping.get
+        say formatted(ping_data)
       end
     end
   end

--- a/lib/mli/cli/vanishing_messages_command.rb
+++ b/lib/mli/cli/vanishing_messages_command.rb
@@ -1,10 +1,13 @@
 module Mli
   module Cli
     class VanishingMessagesCommand < BaseCommand
-      desc "create ATTRS", "Create VanishingMessage record with ATTRS"
+      desc "create", "Create VanishingMessage resource"
       long_desc docs_for(:vanishing_messages, :create), wrap: false
-      def create(*args)
-        vanishing_message_attrs = attrs_for(args)
+      option :body, type: :string, required: true
+      def create
+        vanishing_message_attrs = {
+          body: options[:body]
+        }
         vanishing_message_data = VanishingMessages.create(vanishing_message_attrs)
         say formatted(vanishing_message_data)
       end

--- a/lib/mli/ping.rb
+++ b/lib/mli/ping.rb
@@ -3,7 +3,8 @@ module Mli
     def self.get
       endpoint = "/api/v1/ping"
       response = Mli.connection.get(endpoint)
-      response.body
+      server_time = response.body
+      {server_time: server_time}
     end
   end
 end

--- a/spec/lib/mli/cli/base_command_spec.rb
+++ b/spec/lib/mli/cli/base_command_spec.rb
@@ -1,49 +1,4 @@
 RSpec.describe Mli::Cli::BaseCommand do
-  describe ".attrs_for" do
-    context "with nil args" do
-      it "returns an empty hash" do
-        args = nil
-        attrs = Mli::Cli::BaseCommand.attrs_for(args)
-        expect(attrs).to eq({})
-      end
-    end
-
-    context "with empty args" do
-      it "returns an empty hash" do
-        args = nil
-        attrs = Mli::Cli::BaseCommand.attrs_for(args)
-        expect(attrs).to eq({})
-      end
-    end
-
-    context "with invalid args" do
-      it "returns an empty hash" do
-        args = %w[invalid]
-        attrs = Mli::Cli::BaseCommand.attrs_for(args)
-        expect(attrs).to eq({})
-      end
-    end
-
-    context "with malformed args" do
-      it "returns an empty hash" do
-        args = %w[malformed:]
-        attrs = Mli::Cli::BaseCommand.attrs_for(args)
-        expect(attrs).to eq({})
-      end
-    end
-
-    context "with valid args" do
-      it "returns a hash with those key/value pairs" do
-        args = %w[first_name:jon last_name:allured]
-        attrs = Mli::Cli::BaseCommand.attrs_for(args)
-        expect(attrs).to eq({
-          "first_name" => "jon",
-          "last_name" => "allured"
-        })
-      end
-    end
-  end
-
   describe ".docs_for" do
     context "with a missing topic" do
       let(:topic) { :missing }
@@ -80,6 +35,31 @@ RSpec.describe Mli::Cli::BaseCommand do
           doc_data = Mli::Cli::BaseCommand.docs_for(topic, section)
           expect(doc_data).to eq "  GET /api/v1/found"
         end
+      end
+    end
+  end
+
+  describe "#formatted" do
+    context "without the pretty option" do
+      it "returns normal JSON" do
+        base_command = Mli::Cli::BaseCommand.new
+        dummy_data = {foo: :bar}
+        formatted = base_command.formatted(dummy_data)
+        expect(formatted).to eq '{"foo":"bar"}'
+      end
+    end
+
+    context "with the pretty option" do
+      it "returns pretty JSON" do
+        base_command = Mli::Cli::BaseCommand.new([], %w[--pretty], {})
+        dummy_data = {foo: :bar}
+        formatted = base_command.formatted(dummy_data)
+
+        expect(formatted).to eq(<<~JSON.chomp)
+          {
+            "foo": "bar"
+          }
+        JSON
       end
     end
   end

--- a/spec/lib/mli/cli/ping_command_spec.rb
+++ b/spec/lib/mli/cli/ping_command_spec.rb
@@ -1,35 +1,13 @@
 RSpec.describe Mli::Cli::PingCommand do
   describe "get" do
-    before do
+    it "prints server time" do
       faraday_stubs.get("/api/v1/ping") { [200, {}, "123456"] }
-    end
+      expected_output = {server_time: "123456"}.to_json + "\n"
 
-    context "with no flags" do
-      let(:argument_vector) { %w[get] }
-
-      it "prints server time in plain text" do
-        expected_output = "123456\n"
-
-        expect do
-          Mli::Cli::PingCommand.start(argument_vector)
-        end.to output(expected_output).to_stdout
-      end
-    end
-
-    context "with pretty flag" do
-      let(:argument_vector) { %w[get --pretty] }
-
-      it "prints server time in pretty format" do
-        expected_output = <<~JSON
-          {
-            "server_time": "123456"
-          }
-        JSON
-
-        expect do
-          Mli::Cli::PingCommand.start(argument_vector)
-        end.to output(expected_output).to_stdout
-      end
+      expect do
+        argument_vector = %w[get]
+        Mli::Cli::PingCommand.start(argument_vector)
+      end.to output(expected_output).to_stdout
     end
   end
 end

--- a/spec/lib/mli/cli/vanishing_messages_command_spec.rb
+++ b/spec/lib/mli/cli/vanishing_messages_command_spec.rb
@@ -7,22 +7,9 @@ RSpec.describe Mli::Cli::VanishingMessagesCommand do
       faraday_stubs.post("/api/v1/vanishing_messages") { api_response }
     end
 
-    context "without required attr" do
-      let(:api_response) { error_response }
-      let(:argument_vector) { %w[create] }
-
-      it "prints error message" do
-        expected_output = {error: "bad request"}.to_json + "\n"
-
-        expect do
-          Mli::Cli::VanishingMessagesCommand.start(argument_vector)
-        end.to output(expected_output).to_stdout
-      end
-    end
-
-    context "with required attr" do
+    context "with required options" do
       let(:api_response) { success_response }
-      let(:argument_vector) { %w[create body:shhh] }
+      let(:argument_vector) { %w[create --body shhh] }
 
       it "prints success message" do
         expected_output = {abracadabra: "poof!"}.to_json + "\n"

--- a/spec/lib/mli/ping_spec.rb
+++ b/spec/lib/mli/ping_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe Mli::Ping do
   describe ".get" do
-    it "gets the ping endpoint and returns server time as string" do
+    it "gets the ping endpoint and returns server time" do
       endpoint = "/api/v1/ping"
       response = double(:mock_response, body: "123456")
       expect(Mli.connection).to receive(:get).with(endpoint).and_return(response)
       server_time = Mli::Ping.get
-      expect(server_time).to eq "123456"
+      expect(server_time).to eq({server_time: "123456"})
     end
   end
 end


### PR DESCRIPTION
Prior to this PR I was taking all of the various attributes for a resource as arguments to the command method. This meant that to create a `Book` resource, for example, here's what I would have to do with the CLI:

```
$ mli books create format:print isbn:123-456-789 finished_on:2025-01-01
```

Using a `key:value` syntax. But what if I wanted to provide a value that includes spaces?

```
$ mli books create format:print isbn:123-456-789 finished_on:2025-01-01 "title:Very Good Book"
```

I had to put quotes around the whole key/value pair and it just look ugly. It also meant that I didn't really have anything at the CLI-level doing any type of sanity check. In the case of a `Book` resource I know that `format` is required but that only came through via an API call and then a Rails validation message coming back. That's silly! And in fact if I use `option` instead then I can provide the allowed values as well.

These 2 things convinced me that I was missing out by not using `option` so this PR moves to that pattern.