### PR TITLE
Build from flat attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog][] and this project adheres to
 
 * Configure spec task without verbose output ([#9][])
 * Fix some reorg fallout ([#14][])
+* Build from flat attrs ([#16][])
 
 ### Security
 
@@ -80,3 +81,4 @@ The format is based on [Keep a Changelog][] and this project adheres to
 [#13]: https://github.com/jonallured/mli/pull/13
 [#14]: https://github.com/jonallured/mli/pull/14
 [#15]: https://github.com/jonallured/mli/pull/15
+[#16]: https://github.com/jonallured/mli/pull/16

--- a/lib/mli/resources/warm_fuzzy.rb
+++ b/lib/mli/resources/warm_fuzzy.rb
@@ -2,7 +2,8 @@ module Mli
   class WarmFuzzy
     def self.create(attrs)
       endpoint = "/api/v1/warm_fuzzies"
-      params = Mli::ParamBuilder.from(warm_fuzzy: attrs)
+      warm_fuzzy_params = Mli::ParamBuilder.from(attrs)
+      params = {warm_fuzzy: warm_fuzzy_params}
       response = Mli.connection.post(endpoint, params)
       response.body
     end
@@ -17,14 +18,15 @@ module Mli
 
     def self.list(page)
       endpoint = "/api/v1/warm_fuzzies"
-      params = Mli::ParamBuilder.from(page: page)
+      params = {page: page}
       response = Mli.connection.get(endpoint, params)
       response.body
     end
 
     def self.update(id, attrs)
       endpoint = "/api/v1/warm_fuzzies/#{id}"
-      params = Mli::ParamBuilder.from(warm_fuzzy: attrs)
+      warm_fuzzy_params = Mli::ParamBuilder.from(attrs)
+      params = {warm_fuzzy: warm_fuzzy_params}
       response = Mli.connection.put(endpoint, params)
       response.body
     end

--- a/spec/lib/mli/cli/warm_fuzzy_command_spec.rb
+++ b/spec/lib/mli/cli/warm_fuzzy_command_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Mli::Cli::WarmFuzzyCommand do
           "author" => "Your Biggest Fan",
           "body" => "I think you are just okay.",
           "received_at" => "2026-01-01T00:00:00Z",
-          "screenshot_path" => "test.png",
+          "screenshot_path" => "spec/fixtures/code.png",
           "title" => "Just Okay"
         }
 
@@ -99,7 +99,7 @@ RSpec.describe Mli::Cli::WarmFuzzyCommand do
             "--body",
             "I think you are just okay.",
             "--screenshot_path",
-            "test.png"
+            "spec/fixtures/code.png"
           ]
 
           Mli::Cli::RootCommand.start(argument_vector)


### PR DESCRIPTION
I'm not 100% sure what I was thinking here but we need to build from the flat attrs rather than sending them in with the model namespace. I actually had a failing test once I fixed this so that what the diff there is about.